### PR TITLE
docs: fix description of include directive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 3. Add an `include` directive to your `foot.ini`:
 
 ```ini
-include /path/to/theme/rose-pine-dawn
+include = /absolute/path/to/theme/rose-pin-dawn
 ```
 
 ## Notes


### PR DESCRIPTION
Correct usage of directives as it expects `key-pair` values and `include` expects an absolute path.